### PR TITLE
createアクションの手動入力箇所を削除、paramsにepisodeを追加 #26

### DIFF
--- a/app/controllers/contents_controller.rb
+++ b/app/controllers/contents_controller.rb
@@ -31,28 +31,16 @@ class ContentsController < ApplicationController
   end
 
   def create
-    @content = current_user.contents.build(content_params)
-    
-    if params[:content][:master_id] #マスタからの登録
+    if params[:content][:master_id]
       @master_ids = params[:content][:master_id]
       @master_ids.each do |master_id|
         master = Master.find(master_id.to_i)
-        @content = current_user.contents.create!(title: master.title, media: master.media, url: master.url, stream: master.stream, registered: true, master_id: master.id)
+        @content = current_user.contents.create!(title: master.title, media: master.media, url: master.url, stream: master.stream, registered: true, episode: master.episode, master_id: master.id)
         current_user.schedules.create!(content_id: @content.id, day: @content.stream_i18n)
       end
       redirect_to contents_path, alert: "#{@master_ids.size}件のタイトルと時間割を登録しました"
-
-    else #手動入力による登録
-      if @content.save
-        current_user.contents << @content
-        unless current_user.schedules.where(position: 5).where(day: @content.stream_i18n).exists?
-          current_user.schedules.create!(content_id: @content.id, day: @content.stream_i18n)
-          @content.update(registered: true)
-        end
-        redirect_to contents_path, alert: "#{@content.title}を登録しました"
-      else
-        render :new
-      end
+    else
+      render :index, alert: "タイトル登録が失敗しました"
     end
   end
 
@@ -100,7 +88,7 @@ class ContentsController < ApplicationController
   private
 
   def content_params
-    params.require(:content).permit(:title, :media, :url, :stream, :new_flag, :master_id => [])
+    params.require(:content).permit(:title, :media, :url, :stream, :new_flag, :episode, :master_id => [])
   end
 
   def result


### PR DESCRIPTION
#26
・contents_controllerのcreateアクションから手動入力によるタイトル登録の処理を削除
・`content_params`に`episode`を追加し、マスタ登録時にcontentインスタンスにも`episode`が反映されるように設定